### PR TITLE
Fix typo 'Massachussets'

### DIFF
--- a/SVM _OneVSAll/SVM _OneVSAll/SVMPreprocessor/bin/Debug/train/talk.politics.misc/178847
+++ b/SVM _OneVSAll/SVM _OneVSAll/SVMPreprocessor/bin/Debug/train/talk.politics.misc/178847
@@ -28,7 +28,7 @@ In article <15APR199320293386@utkvx.utk.edu> drevik@utkvx.utk.edu (Drevik, Steve
     I bet more than 10% kids living in such neighborhoods are already 
     covered by Medicaid.
 
-    Here in Massachussets, we have had a universal immunization program,
+    Here in Massachusetts, we have had a universal immunization program,
     the kind of Clinton seems to be proposing, for many years (two decades?).
     Mass' immunization rate is 65%.  What about the other 35%?  I guess
     some parents are indeed too ignorant or too lazy , or simply do not 


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'Massachusetts', you typed 'Massachussets'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
